### PR TITLE
Update KayTool folder casing for macOS

### DIFF
--- a/ComfyUI-Easy-Install.sh
+++ b/ComfyUI-Easy-Install.sh
@@ -624,7 +624,7 @@ cd ../../..
 get_node https://github.com/CY-CHENYUE/ComfyUI-Janus-Pro
 get_node https://github.com/smthemex/ComfyUI_Sonic
 get_node https://github.com/welltop-cn/ComfyUI-TeaCache
-get_node https://github.com/kk8bit/KayTool
+get_node https://github.com/kk8bit/kaytool
 get_node https://github.com/shiimizu/ComfyUI-TiledDiffusion
 
 # Install onnxruntime for ARM Macs


### PR DESCRIPTION
This is a fix specially for macOS where KayTool is not able to load the GuLuLu image because of the folder casing.

![image](https://github.com/user-attachments/assets/8adc284f-36be-4f30-8455-558e1c69028e)
