### PR TITLE
ADD: `--depth 1` to git clone

### DIFF
--- a/ComfyUI-Easy-Install.sh
+++ b/ComfyUI-Easy-Install.sh
@@ -125,7 +125,7 @@ install_comfyui() {
         rm -rf ComfyUI
     fi
     git config --global credential.helper ""
-    git clone https://github.com/Comfy-Org/ComfyUI ComfyUI
+    git clone --depth 1 https://github.com/Comfy-Org/ComfyUI ComfyUI
     if [ ! -d "ComfyUI" ]; then
         echo -e "${RED}Failed to clone ComfyUI. Please check your internet connection and git setup.${RESET}"
         exit 1


### PR DESCRIPTION
By adding `--depth 1` to git clone, git will only download latest commit and not all package history, saving bandwidth, disk space and time.